### PR TITLE
🐛(project) fix footer menu configuration

### DIFF
--- a/config/_default/menus.fr.toml
+++ b/config/_default/menus.fr.toml
@@ -45,5 +45,5 @@
 
 [[footer]]
   name = "INFN Poitiers"
-  pageRef = "https://www.infn.fr/sites-enseignement/poitiers/"
+  url = "https://www.infn.fr/sites-enseignement/poitiers/"
   weight = 10


### PR DESCRIPTION
A footer menu entry used to redirect to "INFN Poitiers" website was using the
wrong parameter. `pageRef` is used for content within and `url` for external
links.
