### PR TITLE
👷(project) allow manual deployment on `main` branch

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -61,8 +61,8 @@ jobs:
 
   # Deployment job
   deploy:
-    # Only run when push on default branch
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Allow deployment on main branch
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
`deploy` job is allowed only on push on main branch which is too restrictive.
Sometimes it is necessary to rerun deploy job manually from the GH Actions
interface. The run condition on `push` event for `deploy` job is removed.

